### PR TITLE
Vulnerability fix (powered by Mobb Autofixer)

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/xxe/Ping.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/Ping.java
@@ -48,7 +48,7 @@ public class Ping {
   public String logRequest(
       @RequestHeader("User-Agent") String userAgent, @RequestParam(required = false) String text) {
     String logLine = String.format("%s %s %s", "GET", userAgent, text);
-    log.debug(logLine);
+    log.debug(String.valueOf(logLine).replace("\n", "").replace("\r", ""));
     File logFile = new File(webGoatHomeDirectory, "/XXE/log" + webSession.getUserName() + ".txt");
     try {
       try (PrintWriter pw = new PrintWriter(logFile)) {


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **Log Forging** issue reported by **Checkmarx**.

## Issue description
Log Forging allows attackers to manipulate log files by injecting malicious content. This can be used to obfuscate attack traces or forge log entries to conceal unauthorized activities.
 
## Fix instructions
Implement proper input sanitization to remove new lines for values going to the log.



[More info and fix customization are available in the Mobb platform](http://localhost:5173/organization/b9fb72b0-783e-4956-9862-5bae32a00a86/project/70ed3dcd-b8cc-4257-a720-89ea3cd690d4/report/de5f8790-6213-481b-a2af-62ad0d347b4b/fix/b1172a56-f371-4275-8838-f5e518b91d52)